### PR TITLE
[DRAFT] Add structures for editing Unreal data structures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ obj/
 /packages/
 riderModule.iml
 /_ReSharper.Caches/
+
+# Visual Studio build files
+.vs

--- a/UE.Toolkit.Core/Types/Interfaces/IContainerAllocationPolicies.cs
+++ b/UE.Toolkit.Core/Types/Interfaces/IContainerAllocationPolicies.cs
@@ -1,0 +1,89 @@
+﻿using System.Numerics;
+
+namespace UE.Toolkit.Core.Types.Interfaces;
+
+// Advanced settings for how allocations should be controlled for Unreal data structures
+// This is likely unnecessary, but it may come useful in the future.
+// Runtime/Core/Containers/ContainerAllocationPolicies
+public interface ContainerAllocationPolicy<TType, TSize>
+    where TType : unmanaged where TSize : INumber<TSize>
+{
+    public bool HasAllocation();
+    public TSize GetInitialCapacity();
+    public nint GetAllocatedSize(TSize NumAllocatedElements, nint NumBytesPerElement);
+    public unsafe TType* GetAllocation();
+    public unsafe void SetAllocation(TType* Alloc);
+}
+
+/// <summary>
+/// Elements are always allocated indirectly
+/// Implemented in Unreal Engine using TAlignedHeapAllocator and TSizedHeapAllocator, which other than
+/// differences in how they assign alignments for allocations act identically.
+/// </summary>
+public unsafe abstract class HeapAllocator<TType, TSize> : ContainerAllocationPolicy<TType, TSize>
+    where TType : unmanaged where TSize : INumber<TSize>
+{
+    protected TType* Data;
+    public abstract TSize GetInitialCapacity();
+    public abstract nint GetAllocatedSize(TSize NumAllocatedElements, nint NumBytesPerElement);
+    public bool HasAllocation() => Data != null;
+    public unsafe TType* GetAllocation() => Data;
+    public unsafe void SetAllocation(TType* Alloc) => Data = Alloc;
+}
+
+public unsafe class HeapAllocatorInt32<TType> : HeapAllocator<TType, int>
+    where TType : unmanaged
+{
+    public override int GetInitialCapacity() => 0;
+    public override nint GetAllocatedSize(int NumAllocatedElements, nint NumBytesPerElement) => NumAllocatedElements * NumBytesPerElement;
+}
+
+/// <summary>
+/// Allocates up to a specified number of elements in the same allocation as the container.
+/// Any allocation needed beyond this causes all data to be moved into an indirect allocation
+/// This is the default allocation policy for TBitArray
+/// </summary>
+public unsafe abstract class InlineAllocator<TType, TSize> : ContainerAllocationPolicy<TType, TSize>
+    where TType : unmanaged where TSize : INumber<TSize>
+{
+    protected TType* Heap;
+    protected TSize NumInlineElements;
+
+    public bool HasAllocation() => Heap != null;
+    public TSize GetInitialCapacity() => NumInlineElements;
+    public abstract nint GetAllocatedSize(TSize NumAllocatedElements, nint NumBytesPerElement);
+    public unsafe TType* GetAllocation() => null;
+    public unsafe void SetAllocation(TType* Alloc) { }
+}
+
+public unsafe class InlineAllocatorInt32<TType> : InlineAllocator<TType, int>
+    where TType : unmanaged
+{
+    public override nint GetAllocatedSize(int NumAllocatedElements, nint NumBytesPerElement)
+    {
+        if (NumAllocatedElements > NumInlineElements)
+        {
+            return (NumAllocatedElements - NumInlineElements) * NumBytesPerElement;
+        } else
+        {
+            return 0;
+        }
+    }
+}
+
+
+/// <summary>
+/// Allocates up to a specified number of elements in the same allocation as the container like the
+/// inline allocator. However, it won't provide secondary storage when the inline storage is filled
+/// </summary>
+public unsafe class FixedAllocator<TType, TSize> : ContainerAllocationPolicy<TType, TSize>
+    where TType : unmanaged where TSize : INumber<TSize>
+{
+    protected TSize NumInlineElements;
+    public TSize GetInitialCapacity() => NumInlineElements;
+
+    public bool HasAllocation() => false;
+    public nint GetAllocatedSize(TSize NumAllocatedElements, nint NumBytesPerElement) => 0;
+    public unsafe TType* GetAllocation() => null;
+    public unsafe void SetAllocation(TType* Alloc) { }
+}

--- a/UE.Toolkit.Core/Types/Interfaces/IUnrealMemoryInternal.cs
+++ b/UE.Toolkit.Core/Types/Interfaces/IUnrealMemoryInternal.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace UE.Toolkit.Core.Types.Interfaces;
+
+public static class MemoryConstants
+{
+    /// <summary>
+    /// Blocks >= 16 bytes are aligned to 16 bytes, otherwise aligned to 8 bytes
+    /// </summary>
+    public const int DEFAULT_ALIGNMENT = 0;
+}
+
+public interface IUnrealMemoryInternal
+{
+    /// <summary>
+    /// Allocates a block of memory with the global <c>FMemory</c>.
+    /// </summary>
+    /// <param name="count">Number of bytes to allocate.</param>
+    /// <param name="alignment">Alignment of allocation.</param>
+    /// <returns>Pointer to the allocated memory.</returns>
+    /// <remarks>Should only be used after Unreal has finished loading.</remarks>
+    nint Malloc(nint count, int alignment = MemoryConstants.DEFAULT_ALIGNMENT);
+
+    /// <summary>
+    /// Deallocates a block of memory allocated with the global <c>FMemory</c>.
+    /// </summary>
+    /// <param name="original">Pointer to the memory block to free.</param>
+    /// <remarks>Should only be used after Unreal has finished loading.</remarks>
+    void Free(nint original);
+
+    /// <summary>
+    /// Reallocates a block of memory with a new size using the global <c>FMemory</c>.
+    /// </summary>
+    /// <param name="ptr">Old pointer to move data from.</param>
+    /// <param name="count">Number of bytes to allocate.</param>
+    /// <param name="alignment">Alignment of allocation.</param>
+    /// <returns>Pointer to the reallocated memory.</returns>
+    /// <remarks>Should only be used after Unreal has finished loading.</remarks>
+    nint Realloc(nint ptr, nint count, int alignment = MemoryConstants.DEFAULT_ALIGNMENT);
+
+    /// <summary>
+    /// Queries the global <c>FMemory</c> to get the size of an allocation created using it.
+    /// </summary>
+    /// <param name="ptr">Old pointer to move data from.</param>
+    /// <param name="size">Size of the allocation, if the function succeeds</param>
+    /// <returns>Indicates if the pointer is to a memory block allocated by <c>FMemory</c></returns>
+    /// <remarks>Should only be used after Unreal has finished loading.</remarks>
+    bool GetAllocSize(nint ptr, ref nint size);
+
+    /// <summary>
+    /// Allocates and clears a block of memory with the global <c>FMemory</c>.
+    /// </summary>
+    /// <param name="count">Number of bytes to allocate.</param>
+    /// <param name="alignment">Alignment of allocation.</param>
+    /// <returns>Pointer to the allocated memory.</returns>
+    /// <remarks>Should only be used after Unreal has finished loading.</remarks>
+    nint MallocZeroed(nint count, int alignment = MemoryConstants.DEFAULT_ALIGNMENT);
+    /// <summary>
+    /// For some allocators this will return the actual size that should be requested to eliminate internal fragmentation.
+    /// </summary>
+    /// <param name="self">Instance of GMalloc</param>
+    /// <param name="count">Minimum size of allocation</param>
+    /// <param name="alignment">Alignment of allocation</param>
+    /// <returns></returns>
+    nint QuantizeSize(nint count, int alignment = MemoryConstants.DEFAULT_ALIGNMENT);
+}

--- a/UE.Toolkit.Core/Types/Ptr.cs
+++ b/UE.Toolkit.Core/Types/Ptr.cs
@@ -1,7 +1,11 @@
 namespace UE.Toolkit.Core.Types;
 
-public readonly unsafe struct Ptr<T>(T* value)
+public readonly unsafe struct Ptr<T>(T* value) : IEquatable<Ptr<T>>
     where T : unmanaged
 {
     public readonly T* Value = value;
+
+    public bool Equals(Ptr<T> other) => Value == other.Value;
+    public static bool operator ==(Ptr<T> a, Ptr<T> b) => a.Equals(b);
+    public static bool operator !=(Ptr<T> a, Ptr<T> b) => !a.Equals(b);
 }

--- a/UE.Toolkit.Core/Types/Unreal/UE5_4_4/TArray.cs
+++ b/UE.Toolkit.Core/Types/Unreal/UE5_4_4/TArray.cs
@@ -1,6 +1,9 @@
 // ReSharper disable InconsistentNaming
 
+using System;
+using System.Collections;
 using System.Runtime.InteropServices;
+using UE.Toolkit.Core.Types.Interfaces;
 
 namespace UE.Toolkit.Core.Types.Unreal.UE5_4_4;
 
@@ -10,4 +13,266 @@ public unsafe struct TArray<T> where T : unmanaged
     public T* AllocatorInstance;
     public int ArrayNum;
     public int ArrayMax;
+}
+
+/// <summary>
+/// <para>
+/// A dynamically sizable array of typed elements. Assumes that your elements can be relocated without a copy constructor.
+/// The main implication is that pointers to elements in the TArray may be invalidated when adding or removing other elements
+/// within the array. Removal of elements is O(N) and invalidates the indices of subsequent elements.
+/// </para>
+/// <para>
+/// WARNING: Removal methods such as <c>Clear()</c> and <c>Remove()</c> do not invoke the destructor for the inner object!
+/// The user has to manually invoke the destructor by calling <c>Dispose()</c> on the target object!
+/// </para>
+/// </summary>
+/// <typeparam name="TType">The type to store instances of </typeparam>
+public unsafe class TArrayList<TType> : IDisposable, IList<TType> where TType : unmanaged
+// TArrayListBase<TType, TStrategy = HeapAllocator<TType, int32>, TSize = int32>
+{
+    protected TArray<TType>* Self;
+    protected IUnrealMemoryInternal Allocator;
+    protected bool OwnsInstance;
+    protected bool Disposed = false;
+
+    private const int DEFAULT_ARRAY_SIZE = 4;
+
+    /// <summary>
+    /// Wraps a <c>TArrayList</c> around an existing <c>TArray</c> created in C++
+    /// </summary>
+    /// <param name="_Self">Pointer to an existing <c>TArray</c></param>
+    /// <param name="_Allocator">The Unreal allocator, used for methods that modify the <c>TArray</c></param>
+    public unsafe TArrayList(TArray<TType>* _Self, IUnrealMemoryInternal _Allocator)
+    {
+        Self = _Self;
+        Allocator = _Allocator;
+        OwnsInstance = false;
+    }
+
+    /// <summary>
+    /// Creates a new <c>TArrayList</c> by allocating an owned <c>TArray</c> that frees itself when this object is garbage collected.
+    /// </summary>
+    /// <param name="_Allocator">The Unreal allocator, used for methods that modify the <c>TArray</c></param>
+    public unsafe TArrayList(IUnrealMemoryInternal _Allocator)
+    {
+        Allocator = _Allocator;
+        Self = (TArray<TType>*)Allocator.MallocZeroed(sizeof(TArray<TType>));
+        OwnsInstance = true;
+    }
+
+    public unsafe TType* Allocation
+    {
+        get => Self->AllocatorInstance;
+        private set => Self->AllocatorInstance = value;
+    }
+
+    public int ArrayNum
+    {
+        get => Self->ArrayNum;
+        protected set => Self->ArrayNum = value;
+    }
+
+    public int ArrayMax
+    {
+        get => Self->ArrayMax;
+        protected set => Self->ArrayMax = value;
+    }
+
+    public unsafe TArray<TType>* Base() => Self;
+
+    bool InBounds(int index) => index >= 0 && index < ArrayNum;
+    bool InBoundsForInsertion(int index) => index >= 0 && index <= ArrayNum;
+
+    int CalculateNewArraySize() => (Allocation != null) ? ArrayMax * 2 : DEFAULT_ARRAY_SIZE;
+
+    /// <summary>
+    /// Relinquish ownership of this <c>TArray</c>. This is used in cases where you know that Unreal will deallocate it or it otherwise
+    /// doesn't need deallocation.
+    /// </summary>
+    public void Leak() => OwnsInstance = false;
+
+    public void ResizeTo(int newSize)
+    {
+        var newAlloc = (TType*)Allocator.Malloc(sizeof(TType) * newSize);
+        if (Allocation != null)
+        {
+            NativeMemory.Copy(Allocation, newAlloc, (nuint)(ArrayMax * sizeof(TType)));
+            Allocator.Free((nint)Allocation);
+        }
+        Allocation = newAlloc;
+        ArrayMax = newSize;
+    }
+
+    public void Resize() => ResizeTo(CalculateNewArraySize());
+
+    void InsertInner(int index, TType item, bool add)
+    {
+        if (add)
+        {
+            // Allow assigning to this[ArrayNum] to add a new entry
+            if (!InBoundsForInsertion(index))
+            {
+                return;
+            }
+            if (ArrayNum == ArrayMax)
+            {
+                Resize();
+            }
+            // Shift elements to the right
+            for (int i = ArrayNum; i > index; i--)
+            {
+                Allocation[i] = Allocation[i - 1];
+            }
+            ArrayNum++;
+        } else
+        {
+            // We're only replacing existing entries, so this[ArrayNum] is out of bounds
+            if (!InBounds(index))
+            {
+                return;
+            }
+        }
+        Allocation[index] = item;
+    }
+
+    #region LIST INTERFACE
+
+    public TType this[int index] 
+    { 
+        get 
+        {
+            if (InBounds(index))
+            {
+                return Allocation[index];
+            } else
+            {
+                throw new IndexOutOfRangeException();
+            }
+        }
+        set => InsertInner(index, value, false);
+    }
+
+    public int Count => ArrayNum;
+
+    public bool IsReadOnly => false;
+
+    public void Add(TType item) => Insert(Count, item);
+
+    public void Clear() => ArrayNum = 0;
+
+    public bool Contains(TType item)
+    {
+        foreach (var el in this)
+        {
+            if (el.Equals(item))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public void CopyTo(TType[] array, int arrayIndex)
+    {
+        if (!InBounds(arrayIndex))
+        {
+            return;
+        }
+        for (int i = 0; i < ArrayNum - arrayIndex; i++)
+        {
+            array[i] = Allocation[i + arrayIndex];
+        }
+    }
+
+    public IEnumerator<TType> GetEnumerator() => new TArrayEnumerator<TType>(this);
+
+    public int IndexOf(TType item)
+    {
+        int index = 0;
+        foreach (var el in this)
+        {
+            if (el.Equals(item))
+            {
+                return index;
+            }
+            index++;
+        }
+        return -1;
+    }
+
+    public void Insert(int index, TType item) => InsertInner(index, item, true);
+    public bool Remove(TType item)
+    {
+        int ItemIndex = IndexOf(item);
+        if (ItemIndex != -1)
+        {
+            RemoveAt(ItemIndex);
+            return true;
+        }
+        return false;
+    }
+
+    public void RemoveAt(int index)
+    {
+        if (!InBounds(index))
+        {
+            return;
+        }
+        // Shift elements to the left
+        for (int i = index; i < ArrayNum - 1; i++)
+        {
+            Allocation[i] = Allocation[i + 1];
+        }
+        ArrayNum--;
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    #endregion
+
+    #region DISPOSE INTERFACE
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!Disposed)
+        {
+            if (disposing) { } // Dispose managed resources
+            // Disposed unmanaged resources (for Unreal)
+            if (Allocation != null)
+            {
+                Allocator.Free((nint)Allocation);
+            }
+            if (OwnsInstance)
+            {
+                Allocator.Free((nint)Self);
+            }
+            Disposed = true;
+        }
+    }
+
+    ~TArrayList() => Dispose(false);
+
+    #endregion
+}
+
+public class TArrayEnumerator<T> : IEnumerator<T> where T : unmanaged
+{
+    protected TArrayList<T> Self;
+    private int position = -1;
+
+    public unsafe object Current
+    {
+        get => Self[position];
+    }
+    public unsafe TArrayEnumerator(TArrayList<T> _Self) => Self = _Self;
+    public unsafe bool MoveNext() => ++position < Self.ArrayNum;
+    T IEnumerator<T>.Current => (T)Current;
+    public void Reset() => position = -1;
+    public void Dispose() { }
 }

--- a/UE.Toolkit.Core/Types/Unreal/UE5_4_4/TArray.cs
+++ b/UE.Toolkit.Core/Types/Unreal/UE5_4_4/TArray.cs
@@ -244,12 +244,12 @@ public unsafe class TArrayList<TType> : IDisposable, IList<TType> where TType : 
         {
             if (disposing) { } // Dispose managed resources
             // Disposed unmanaged resources (for Unreal)
-            if (Allocation != null)
-            {
-                Allocator.Free((nint)Allocation);
-            }
             if (OwnsInstance)
             {
+                if (Allocation != null)
+                {
+                    Allocator.Free((nint)Allocation);
+                }
                 Allocator.Free((nint)Self);
             }
             Disposed = true;

--- a/UE.Toolkit.Core/Types/Unreal/UE5_4_4/TBitArray.cs
+++ b/UE.Toolkit.Core/Types/Unreal/UE5_4_4/TBitArray.cs
@@ -292,12 +292,12 @@ public unsafe class TBitArrayList : IDisposable, IList<bool>
         {
             if (disposing) { } // Dispose managed resources
             // Disposed unmanaged resources (for Unreal)
-            if (Allocation != null)
-            {
-                Allocator.Free((nint)Allocation);
-            }
             if (OwnsInstance)
             {
+                if (Allocation != null)
+                {
+                    Allocator.Free((nint)Allocation);
+                }
                 Allocator.Free((nint)Self);
             }
             Disposed = true;

--- a/UE.Toolkit.Core/Types/Unreal/UE5_4_4/TBitArray.cs
+++ b/UE.Toolkit.Core/Types/Unreal/UE5_4_4/TBitArray.cs
@@ -49,6 +49,7 @@ public unsafe class TBitArrayList : IDisposable, IList<bool>
     public unsafe TBitArrayList(byte* _Self, IUnrealMemoryInternal _Allocator, int _InlineAllocatorSize = TBitArrayConstants.DEFAULT_ALLOCATOR_SIZE)
     {
         Allocator = _Allocator;
+        InlineAllocatorSize = _InlineAllocatorSize;
         Self = _Self;
         OwnsInstance = false;
     }
@@ -66,23 +67,23 @@ public unsafe class TBitArrayList : IDisposable, IList<bool>
         OwnsInstance = true;
     }
 
-    public unsafe byte* Inline
+    protected unsafe byte* Inline
     {
         get => Self;
     }
 
-    public int InlineBits => InlineAllocatorSize * TBitArrayConstants.BITS_PER_BYTE;
+    internal int InlineBits => InlineAllocatorSize * TBitArrayConstants.BITS_PER_BYTE;
 
-    public unsafe byte* Allocation
+    protected unsafe byte* Allocation
     {
         get => *(byte**)(Self + InlineAllocatorSize);
-        protected set => *(byte**)(Self + InlineAllocatorSize) = value;
+        set => *(byte**)(Self + InlineAllocatorSize) = value;
     }
 
-    public unsafe byte* Data
+    protected unsafe byte* Data
     {
         get => (Allocation != null) ? Allocation : Inline;
-        protected set
+        set
         {
             if (Allocation != null)
             {

--- a/UE.Toolkit.Core/Types/Unreal/UE5_4_4/TBitArray.cs
+++ b/UE.Toolkit.Core/Types/Unreal/UE5_4_4/TBitArray.cs
@@ -1,4 +1,6 @@
+using System.Collections;
 using System.Runtime.InteropServices;
+using UE.Toolkit.Core.Types.Interfaces;
 
 // ReSharper disable InconsistentNaming
 
@@ -10,4 +12,311 @@ public unsafe struct TBitArray
     public int* AllocatorInstance;
     public int NumBits;
     public int MaxBits;
+}
+
+internal static class TBitArrayConstants // TInlineAllocator<4>
+{
+    internal const int BITS_PER_BYTE = 0x8;
+    internal const int DEFAULT_ALLOCATOR_SIZE = sizeof(int) * 4;
+    internal const int BYTE_MAX = byte.MaxValue;
+}
+
+/// <summary>
+/// <para>
+/// A dynamically sized bit array. Represents an array of booleans, which are stored as one bit each.
+/// </para>
+/// </summary>
+public unsafe class TBitArrayList : IDisposable, IList<bool>
+// TArrayListBase<TType, TStrategy = InlineAllocator<int, int32, 4>, TSize = int32>
+{
+    // Inline allocators insert their elements as the first field of the structure, followed by the heap pointer
+    // then the count + capacity fields
+
+    // The inline allocation policy allocates up to a specified number of elements in the same allocation as the container.
+    // Any allocation needed beyond that causes all data to be moved into an indirect allocation.
+    public unsafe byte* Self { get; private set; } // Start with InlineAllocatorSize bytes of inlined flags, then a TArray with remaining flags
+
+    protected IUnrealMemoryInternal Allocator;
+    private int InlineAllocatorSize;
+    protected bool OwnsInstance;
+    protected bool Disposed = false;
+
+    /// <summary>
+    /// Wraps a <c>TArrayList</c> around an existing <c>TBitArray</c> created in C++
+    /// </summary>
+    /// <param name="_Self">Pointer to an existing <c>TBitArray</c></param>
+    /// <param name="_Allocator">The Unreal allocator, used for methods that modify the <c>TBitArray</c></param>
+    public unsafe TBitArrayList(byte* _Self, IUnrealMemoryInternal _Allocator, int _InlineAllocatorSize = TBitArrayConstants.DEFAULT_ALLOCATOR_SIZE)
+    {
+        Allocator = _Allocator;
+        Self = _Self;
+        OwnsInstance = false;
+    }
+
+    /// <summary>
+    /// Creates a new <c>TArrayList</c> by allocating an owned <c>TArray</c> that frees itself when this object is garbage collected.
+    /// </summary>
+    /// <param name="_Allocator">The Unreal allocator, used for methods that modify the <c>TBitArray</c></param>
+    public unsafe TBitArrayList(IUnrealMemoryInternal _Allocator, int _InlineAllocatorSize = TBitArrayConstants.DEFAULT_ALLOCATOR_SIZE)
+    {
+        Allocator = _Allocator;
+        InlineAllocatorSize = _InlineAllocatorSize;
+        Self = (byte*)Allocator.MallocZeroed(GetStructSize());
+        ArrayMax = InlineBits;
+        OwnsInstance = true;
+    }
+
+    public unsafe byte* Inline
+    {
+        get => Self;
+    }
+
+    public int InlineBits => InlineAllocatorSize * TBitArrayConstants.BITS_PER_BYTE;
+
+    public unsafe byte* Allocation
+    {
+        get => *(byte**)(Self + InlineAllocatorSize);
+        protected set => *(byte**)(Self + InlineAllocatorSize) = value;
+    }
+
+    public unsafe byte* Data
+    {
+        get => (Allocation != null) ? Allocation : Inline;
+        protected set
+        {
+            if (Allocation != null)
+            {
+                Allocation = value;
+            }
+        }
+    }
+
+    public int ArrayNum
+    {
+        get => *(int*)(Self + InlineAllocatorSize + sizeof(nint));
+        protected set => *(int*)(Self + InlineAllocatorSize + sizeof(nint)) = value;
+    }
+
+    public int ArrayMax
+    {
+        get => *(int*)(Self + InlineAllocatorSize + sizeof(nint) + sizeof(int));
+        protected set => *(int*)(Self + InlineAllocatorSize + sizeof(nint) + sizeof(int)) = value;
+    }
+
+    bool InBounds(int index) => index >= 0 && index < ArrayNum;
+    bool InBoundsForInsertion(int index) => index >= 0 && index <= ArrayNum;
+    /// <summary>
+    /// Relinquish ownership of this <c>TArray</c>. This is used in cases where you know that Unreal will deallocate it or it otherwise
+    /// doesn't need deallocation.
+    /// </summary>
+    public void Leak() => OwnsInstance = false;
+    private unsafe int GetStructSize() => InlineAllocatorSize + sizeof(nint) + sizeof(int) * 2;
+    private unsafe static int GetDefaultStructSize() => TBitArrayConstants.DEFAULT_ALLOCATOR_SIZE + sizeof(nint) + sizeof(int) * 2;
+    int CalculateNewArraySize() => ArrayMax * 2;
+
+    public void ResizeTo(int newSize)
+    {
+        var newAlloc = Allocator.MallocZeroed(newSize / TBitArrayConstants.BITS_PER_BYTE);
+        if (Allocation != null)
+        { // Resize heap booleans
+            NativeMemory.Copy(Allocation, (void*)newAlloc, (nuint)(ArrayNum / TBitArrayConstants.BITS_PER_BYTE));
+            Allocator.Free((nint)Allocation);
+        } else
+        { // Migrate booleans from inline storage to heap
+            NativeMemory.Copy(Inline, (byte*)newAlloc, (nuint)InlineBits / TBitArrayConstants.BITS_PER_BYTE);
+            NativeMemory.Clear(Inline, (nuint)InlineBits / TBitArrayConstants.BITS_PER_BYTE);
+        }
+        Allocation = (byte*)newAlloc;
+        ArrayMax = newSize;
+    }
+
+    public void Resize() => ResizeTo(CalculateNewArraySize());
+
+    public unsafe byte* Base() => Self;
+
+    void InsertInner(int index, bool item, bool add)
+    {
+        if (add)
+        {
+            // Allow assigning to this[ArrayNum] to add a new entry
+            if (!InBoundsForInsertion(index))
+            {
+                return;
+            }
+            if (ArrayNum == ArrayMax)
+            {
+                Resize();
+            }
+            // Shift elements to the right
+            var StartIndex = ArrayNum / TBitArrayConstants.BITS_PER_BYTE;
+            var EndIndex = index / TBitArrayConstants.BITS_PER_BYTE;
+            for (int i = StartIndex; i >= EndIndex; i--)
+            {
+                Data[i + 1] |= (byte)(Data[i] >> 7);
+                Data[i] <<= 1;
+            }
+            ArrayNum++;
+        }
+        else
+        {
+            // We're only replacing existing entries, so this[ArrayNum] is out of bounds
+            if (!InBounds(index))
+            {
+                return;
+            }
+        }
+        if (item)
+        {
+            Data[index / TBitArrayConstants.BITS_PER_BYTE] |= (byte)(1 << (index % TBitArrayConstants.BITS_PER_BYTE));
+        }
+        else
+        {
+            Data[index / TBitArrayConstants.BITS_PER_BYTE] &= (byte)(TBitArrayConstants.BYTE_MAX ^ (1 << (index % TBitArrayConstants.BITS_PER_BYTE)));
+        }
+    }
+
+    #region LIST INTERFACE
+
+    public bool this[int index] 
+    { 
+        get
+        {
+            if (InBounds(index))
+            {
+                return (Data[index / TBitArrayConstants.BITS_PER_BYTE] & (1 << (index % TBitArrayConstants.BITS_PER_BYTE))) != 0 ? true : false;
+            } else
+            {
+                throw new IndexOutOfRangeException();
+            }
+        }
+        set => InsertInner(index, value, false);
+    }
+
+    public int Count => ArrayNum;
+
+    public bool IsReadOnly => false;
+
+    public void Add(bool item) => Insert(Count, item);
+
+    public void Clear()
+    {
+        NativeMemory.Clear(Data, (nuint)ArrayMax / TBitArrayConstants.BITS_PER_BYTE);
+        ArrayNum = 0;
+    }
+
+    public bool Contains(bool item)
+    {
+        foreach (var b in this)
+        {
+            if (b == item)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public void CopyTo(bool[] array, int arrayIndex)
+    {
+        if (!InBounds(arrayIndex))
+        {
+            return;
+        }
+        for (int i = 0; i < ArrayNum - arrayIndex; i++)
+        {
+            array[i] = this[i + arrayIndex];
+        }
+    }
+
+    public IEnumerator<bool> GetEnumerator() => new TBitArrayEnumerator(this);
+
+    public int IndexOf(bool item)
+    {
+        int index = 0;
+        foreach (var b in this)
+        {
+            if (b == item) return index;
+            index++;
+        }
+        return -1;
+    }
+
+    public void Insert(int index, bool item) => InsertInner(index, item, true);
+
+    public bool Remove(bool item)
+    {
+        int ItemIndex = IndexOf(item);
+        if (ItemIndex != -1)
+        {
+            RemoveAt(ItemIndex);
+            return true;
+        }
+        return false;
+    }
+
+    public void RemoveAt(int index)
+    {
+        if (!InBounds(index))
+        {
+            return;
+        }
+        // Shift elements to the left
+        var StartIndex = index / TBitArrayConstants.BITS_PER_BYTE;
+        var EndIndex = (ArrayNum - 1) / TBitArrayConstants.BITS_PER_BYTE;
+        for (int i = StartIndex; i <= EndIndex; i++)
+        {
+            if (i > 0) 
+            { 
+                Data[i - 1] |= (byte)((Data[i] & 1) << 7); 
+            }
+            Data[i] >>= 1;
+        }
+        ArrayNum--;
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    #endregion
+
+    #region DISPOSE INTERFACE
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!Disposed)
+        {
+            if (disposing) { } // Dispose managed resources
+            // Disposed unmanaged resources (for Unreal)
+            if (Allocation != null)
+            {
+                Allocator.Free((nint)Allocation);
+            }
+            if (OwnsInstance)
+            {
+                Allocator.Free((nint)Self);
+            }
+            Disposed = true;
+        }
+    }
+
+    ~TBitArrayList() => Dispose(false);
+
+    #endregion
+}
+
+public class TBitArrayEnumerator : IEnumerator<bool>
+{
+    private TBitArrayList Owner;
+    private int Index = -1;
+    public TBitArrayEnumerator(TBitArrayList _Owner) { Owner = _Owner; }
+    public bool Current => Owner[Index];
+    object IEnumerator.Current => Current;
+    public void Dispose() { }
+    public bool MoveNext() => ++Index < Owner.Count;
+    public void Reset() => Index = -1;
 }

--- a/UE.Toolkit.Core/Types/Unreal/UE5_4_4/TMap.cs
+++ b/UE.Toolkit.Core/Types/Unreal/UE5_4_4/TMap.cs
@@ -1,7 +1,10 @@
 // ReSharper disable InconsistentNaming
 
 using System.Collections;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
+using UE.Toolkit.Core.Types.Interfaces;
 
 namespace UE.Toolkit.Core.Types.Unreal.UE5_4_4;
 
@@ -23,6 +26,7 @@ public unsafe struct TMap<InKeyType, InValueType>
     // From TSet (probably)
 }
 
+/*
 public unsafe class TMapDictionary<InKeyType, InValueType> : IDictionary<InKeyType, Ptr<InValueType>>, IEnumerator<KeyValuePair<InKeyType, Ptr<InValueType>>>
     where InKeyType : unmanaged
     where InValueType : unmanaged
@@ -161,6 +165,7 @@ public unsafe class TMapDictionary<InKeyType, InValueType> : IDictionary<InKeyTy
 
     #endregion
 }
+*/
 
 [StructLayout(LayoutKind.Sequential)]
 public unsafe struct TMapElement<InKeyType, InValueType>
@@ -169,7 +174,7 @@ public unsafe struct TMapElement<InKeyType, InValueType>
 {
     public InKeyType Key;
     public InValueType* Value;
-    
+
     // From TSetElementBase
     /** The id of the next element in the same hash bucket. */
     public int HashNextId; // FSetElementId
@@ -178,3 +183,531 @@ public unsafe struct TMapElement<InKeyType, InValueType>
     public int HashIndex;
 }
 
+/// <summary>
+/// Defines types that are hashable. Useful in cases such as using it as a key for a <c>TMap</c>
+/// </summary>
+public interface IMapHashable
+{
+    public uint GetTypeHash();
+}
+
+// Built in hashable types
+
+[StructLayout(LayoutKind.Sequential)]
+public unsafe struct TMapElementHashable<KeyType, ValueType>
+    where KeyType : unmanaged, IEquatable<KeyType>, IMapHashable
+    where ValueType : unmanaged
+{
+    public KeyType Key;
+    public ValueType Value;
+    public int HashNextId;
+    public int HashIndex;
+}
+
+public unsafe struct HashablePtr<T> : IMapHashable, IEquatable<HashablePtr<T>> where T: unmanaged
+{
+    public Ptr<T> Ptr;
+    public HashablePtr(Ptr<T> ptr) { Ptr = ptr; }
+    public uint GetTypeHash() // FUN_140904980
+    {
+        uint iVar4 = (uint)((nint)Ptr.Value >> 4);
+        uint uVar3 = 0x9e3779b9U - iVar4 ^ iVar4 << 8;
+        uint uVar1 = (uint)-(uVar3 + iVar4) ^ uVar3 >> 0xd;
+        uint uVar5 = (iVar4 - uVar3) - uVar1 ^ uVar1 >> 0xc;
+        uVar3 = (uVar3 - uVar5) - uVar1 ^ uVar5 << 0x10;
+        uVar1 = (uVar1 - uVar3) - uVar5 ^ uVar3 >> 5;
+        uVar5 = (uVar5 - uVar3) - uVar1 ^ uVar1 >> 3;
+        uVar3 = (uVar3 - uVar5) - uVar1 ^ uVar5 << 10;
+        uint ret = ((uVar1 - uVar3) - uVar5) ^ (uVar3 >> 0xf);
+        return ret;
+    }
+    public bool Equals(HashablePtr<T> other) => Ptr.Value == other.Ptr.Value;
+}
+public unsafe struct HashableInt : IMapHashable, IEquatable<HashableInt>
+{
+    public int Value;
+    public HashableInt(int value) { Value = value; }
+    public uint GetTypeHash() => (uint)Value;
+    public bool Equals(HashableInt other) => other.Value == Value;
+    public override string ToString() => Value.ToString();
+}
+
+[StructLayout(LayoutKind.Explicit, Size = 0x8)]
+public unsafe struct HashableInt8 : IMapHashable, IEquatable<HashableInt8>
+{
+    [FieldOffset(0x0)] public int Value;
+    public HashableInt8(int value) { Value = value; }
+    public uint GetTypeHash() => (uint)Value;
+    public bool Equals(HashableInt8 other) => other.Value == Value;
+    public override string ToString() => Value.ToString();
+}
+
+public static class TypeExtensions
+{
+    public static HashablePtr<T> AsHashable<T> (this Ptr<T> ptr) where T : unmanaged => new(ptr);
+    public static HashableInt AsHashable(this int val) => new(val);
+    public static HashableInt8 AsHashable8(this int val) => new(val);
+    public static uint HashCombine(uint a, uint b)
+    { // FUN_141cbc830
+        uint uVar1 = a - b ^ b >> 0xd;
+        uint uVar3 = (uint)(-0x61c88647 - uVar1) - b ^ uVar1 << 8;
+        uint uVar2 = (b - uVar3) - uVar1 ^ uVar3 >> 0xd;
+        uVar1 = (uVar1 - uVar3) - uVar2 ^ uVar2 >> 0xc;
+        uVar3 = (uVar3 - uVar1) - uVar2 ^ uVar1 << 0x10;
+        uVar2 = (uVar2 - uVar3) - uVar1 ^ uVar3 >> 5;
+        uVar1 = (uVar1 - uVar3) - uVar2 ^ uVar2 >> 3;
+        uVar3 = (uVar3 - uVar1) - uVar2 ^ uVar1 << 10;
+        return (uVar2 - uVar3) - uVar1 ^ uVar3 >> 0xf;
+    }
+}
+
+// Free list for TSet/TMap
+
+public unsafe struct TMapFreeListIndex
+{
+    public int FirstFreeIndex;
+    public int NumFreeIndices;
+    public int* FreeIndexList;
+}
+
+// Look for edge cases where this isn't the case.
+internal static class MapConstants
+{
+    internal const int SIZE_OF_ARRAY = 0x10;
+    internal const int SIZE_OF_BIT_ALLOCATOR = 0x20;
+    internal const int SIZE_OF_FREE_LIST = 0x10;
+}
+
+public class TMapElementAccessor<TElemKey, TElemValue> : IEnumerable<Ptr<TElemValue>>
+    where TElemKey : unmanaged, IEquatable<TElemKey>, IMapHashable
+    where TElemValue : unmanaged
+{
+    protected unsafe TArray<TMapElementHashable<TElemKey, TElemValue>>* Elements;
+
+    public unsafe TMapElementAccessor(TArray<TMapElementHashable<TElemKey, TElemValue>>* _Self)
+    {
+        Self = _Self;
+    }
+
+    public unsafe TArray<TMapElementHashable<TElemKey, TElemValue>>* Self
+    {
+        get => Elements;
+        set => Elements = value;
+    }
+    public unsafe TMapElementHashable<TElemKey, TElemValue>* Allocation
+    {
+        get => Elements->AllocatorInstance;
+        set => Elements->AllocatorInstance = value;
+    }
+    public unsafe int Size
+    {
+        get => Elements->ArrayNum;
+        set => Elements->ArrayNum = value;
+    }
+    public unsafe int Capacity
+    {
+        get => Elements->ArrayMax;
+        set => Elements->ArrayMax = value;
+    }
+
+    public unsafe TElemValue* this[int Index]
+    {
+        get => &Allocation[Index].Value;
+        set => Allocation[Index].Value = *value;
+    }
+    public unsafe TElemKey GetKey(int Index) => Allocation[Index].Key;
+    public unsafe TElemKey SetKey(int Index, TElemKey Key) => Allocation[Index].Key = Key;
+    public unsafe int GetNextHashId(int Index) => Allocation[Index].HashNextId;
+    public unsafe int SetNextHashId(int Index, int Value) => Allocation[Index].HashNextId = Value;
+    public unsafe int GetHashIndex(int Index) => Allocation[Index].HashIndex;
+    public unsafe int SetHashIndex(int Index, int Value) => Allocation[Index].HashIndex = Value;
+    internal unsafe nint GetAddress(int Index) => (nint)(&Allocation[Index]);
+    public unsafe int SizeOf() => sizeof(TMapElementHashable<TElemKey, TElemValue>);
+    public unsafe IEnumerator<Ptr<TElemValue>> GetEnumerator() => new TMapElementAccessorEnumerator<TElemKey, TElemValue>(Self);
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}
+
+public class TMapElementAccessorEnumerator<TElemKey, TElemValue> : IEnumerator<Ptr<TElemValue>>
+    where TElemKey : unmanaged, IEquatable<TElemKey>, IMapHashable
+    where TElemValue : unmanaged
+{
+    protected int Position = -1;
+    protected unsafe TArray<TMapElementHashable<TElemKey, TElemValue>>* Self;
+    public unsafe Ptr<TElemValue> Current => new(&Self->AllocatorInstance[Position].Value);
+
+    public unsafe TMapElementAccessorEnumerator(TArray<TMapElementHashable<TElemKey, TElemValue>>* _Self)
+    {
+        Self = _Self;
+    }
+
+    object IEnumerator.Current => Current;
+
+    public void Dispose() { }
+    public unsafe bool MoveNext() => ++Position < Self->ArrayNum;
+    public void Reset() => Position = -1;
+}
+
+/// <summary>
+/// Maps a particular key to a particular value. This structure provides O(1) performance for finding objects. This requires that the
+/// type defined in <c>TElemKey</c> is <c>IMapHashable</c> (GetTypeHash in Unreal)
+/// </summary>
+/// <typeparam name="TElemKey">Type used for keys</typeparam>
+/// <typeparam name="TElemValue">Type used for values</typeparam>
+public unsafe class TMapDictionary<TElemKey, TElemValue> : IDictionary<TElemKey, Ptr<TElemValue>>, IDisposable
+    where TElemKey : unmanaged, IEquatable<TElemKey>, IMapHashable
+    where TElemValue : unmanaged
+{
+    /// <summary>
+    ///     <c>TMap Structure</c>
+    ///     <list type="bullet">
+    ///         <listheader>
+    ///             <term>TArray</term>
+    ///             <description>Stores a sparse list of elements</description>
+    ///         </listheader>
+    ///         <item>
+    ///             <term><c>TArray&lt;TMapElement&lt;TElemKey, TElemValue&gt;&gt;</c> Elements</term>
+    ///             <description>0x0</description>
+    ///         </item>
+    ///     </list>
+    ///     <list type="bullet">
+    ///         <listheader>
+    ///             <term>TSparseArray</term>
+    ///             <description>Tracks which parts of the allocation have elements assigned to them</description>
+    ///         </listheader>
+    ///         <item>
+    ///             <term><c>TBitArray</c> AllocationFlags</term>
+    ///             <description>0x10</description>
+    ///         </item>
+    ///         <item>
+    ///             <term><c>TMapFreeListIndex*</c> Free List</term>
+    ///             <description>0x30</description>
+    ///         </item>
+    ///         <item>
+    ///             <term><c>int</c> FirstFreeIndex</term>
+    ///             <description>0x38</description>
+    ///         </item>
+    ///         <item>
+    ///             <term><c>int</c> NumFreeIndices</term>
+    ///             <description>0x3c</description>
+    ///         </item>
+    ///     </list>
+    ///     <list type="bullet">
+    ///         <listheader>
+    ///             <term>TSet</term>
+    ///             <description>Hashes</description>
+    ///         </listheader>
+    ///         <item>
+    ///             <term><c>int*</c> Hash</term>
+    ///             <description>0x40</description>
+    ///         </item>
+    ///         <item>
+    ///             <term><c>int</c> HashSize</term>
+    ///             <description>0x48</description>
+    ///         </item>
+    ///     </list>
+    /// </summary>
+    public unsafe nint Self { get; private set; }
+
+    protected IUnrealMemoryInternal Allocator;
+    protected TMapElementAccessor<TElemKey, TElemValue> Elements;
+    protected TBitArrayList BitAllocator;
+    protected Action<string>? DebugCallback;
+    protected bool OwnsInstance;
+    protected bool Disposed = false;
+
+    private unsafe TArray<TMapElementHashable<TElemKey, TElemValue>>* ElementsRaw
+    {
+        get => (TArray<TMapElementHashable<TElemKey, TElemValue>>*)Self;
+    }
+
+    private unsafe byte* BitAllocatorRaw
+    {
+        get => (byte*)(Self + MapConstants.SIZE_OF_ARRAY);
+    }
+
+    private unsafe TMapFreeListIndex* FreeList
+    {
+        get => (TMapFreeListIndex*)(Self + MapConstants.SIZE_OF_ARRAY + MapConstants.SIZE_OF_BIT_ALLOCATOR);
+    }
+
+    private unsafe int* FirstFreeIndexPtr
+    {
+        get => (int*)(Self + MapConstants.SIZE_OF_ARRAY + MapConstants.SIZE_OF_BIT_ALLOCATOR + sizeof(nint));
+    }
+    private unsafe int FirstFreeIndex
+    {
+        get => *FirstFreeIndexPtr;
+        set => *FirstFreeIndexPtr = value;
+    }
+
+    private unsafe int* NumFreeIndicesPtr
+    {
+        get => (int*)(Self + MapConstants.SIZE_OF_ARRAY + MapConstants.SIZE_OF_BIT_ALLOCATOR + sizeof(nint) + sizeof(int));
+    }
+    private unsafe int NumFreeIndices
+    {
+        get => *NumFreeIndicesPtr;
+        set => *NumFreeIndicesPtr = value;
+    }
+
+    private unsafe int** HashesPtr
+    {
+        get => (int**)(Self + MapConstants.SIZE_OF_ARRAY + MapConstants.SIZE_OF_BIT_ALLOCATOR + MapConstants.SIZE_OF_FREE_LIST);
+    }
+    private unsafe int* Hashes
+    {
+        get => *HashesPtr;
+        set => *HashesPtr = value;
+    }
+
+    private unsafe int* HashSizePtr
+    {
+        get => (int*)(Self + MapConstants.SIZE_OF_ARRAY + MapConstants.SIZE_OF_BIT_ALLOCATOR + MapConstants.SIZE_OF_FREE_LIST + sizeof(nint));
+    }
+    private unsafe int HashSize
+    {
+        get => *HashSizePtr;
+        set => *HashSizePtr = value;
+    }
+
+    // 0x50
+    private static int SizeOf => MapConstants.SIZE_OF_ARRAY + MapConstants.SIZE_OF_BIT_ALLOCATOR + MapConstants.SIZE_OF_FREE_LIST + sizeof(nint) + sizeof(nint);
+
+    private const int DEFAULT_ARRAY_SIZE = 4;
+    private static int MIN_SIZE_FOR_HASH_LIST = 0x4;
+    private static int HASH_INITIAL_SIZE = 0x10;
+
+    /// <summary>
+    /// Wraps a <c>TArrayList</c> around an existing <c>TArray</c> created in C++
+    /// </summary>
+    /// <param name="_Self">Pointer to an existing <c>TArray</c></param>
+    /// <param name="_Allocator">The Unreal allocator, used for methods that modify the <c>TArray</c></param>
+    public unsafe TMapDictionary(TMap<TElemKey, TElemValue>* _Self, IUnrealMemoryInternal _Allocator, Action<string>? _DebugCallback = null)
+    {
+        Self = (nint)_Self;
+        Elements = new(ElementsRaw);
+        Allocator = _Allocator;
+        OwnsInstance = false;
+        BitAllocator = new(BitAllocatorRaw, Allocator);
+        DebugCallback = _DebugCallback;
+    }
+
+    private unsafe TElemValue* TryGetLinear(TElemKey key)
+    {
+        if (Elements.Size == 0) return null;
+        for (int i = 0; i < Elements.Size; i++)
+        {
+            if (Elements.GetKey(i).Equals(key))
+            {
+                return Elements[i];
+            }
+        }
+        return null;
+    }
+
+    private unsafe TElemValue* TryGetByHash(TElemKey key)
+    {
+        TElemValue* value = null;
+        // Hash alloc doesn't exist for single element maps,
+        // so fallback to linear search
+        if (Hashes == null) return TryGetLinear(key);
+        var elementTarget = Hashes[key.GetTypeHash() & (HashSize - 1)];
+        while (elementTarget != -1)
+        {
+            if (Elements.GetKey(elementTarget).Equals(key))
+            {
+                value = Elements[elementTarget];
+                break;
+            }
+            elementTarget = Elements.GetNextHashId(elementTarget);
+        }
+        return value;
+    }
+    private unsafe int GetBucketListTail(int HashIndex)
+    {
+        int currentIndex = Hashes[HashIndex];
+        while (true)
+        {
+            if (Elements.GetNextHashId(currentIndex) == -1) break;
+            currentIndex = Elements.GetNextHashId(currentIndex);
+        }
+        return currentIndex;
+    }
+
+    private unsafe void Rehash(int NewSize)
+    {
+        
+        int* NewHashAlloc = (int*)Allocator.Malloc(sizeof(int) * NewSize);
+        NativeMemory.Fill(NewHashAlloc, (nuint)(NewSize * sizeof(int)), 0xff);
+        if (Hashes != null) Allocator.Free((nint)Hashes);
+        Hashes = NewHashAlloc;
+        for (int i = 0; i < Elements.Size; i++)
+        {
+            var newHashIndex = (int)Elements.GetKey(i).GetTypeHash() & (NewSize - 1);
+            Elements.SetHashIndex(i, newHashIndex);
+            if (Hashes[newHashIndex] == -1) Hashes[newHashIndex] = i;
+            else Elements.SetNextHashId(GetBucketListTail(newHashIndex), i);
+            Elements.SetNextHashId(i, -1);
+        }
+        HashSize = NewSize;
+    }
+
+    private unsafe void ResizeTo(int NewSize)
+    {
+
+        nint NewElementAlloc = Allocator.Malloc(NewSize * Elements.SizeOf());
+        if (Elements.Allocation != null)
+        {
+            NativeMemory.Copy((byte*)Elements.Allocation, (byte*)NewElementAlloc, (nuint)(Elements.Size * Elements.SizeOf()));
+            Allocator.Free((nint)Elements.Allocation);
+        }
+        Elements.Allocation = (TMapElementHashable<TElemKey, TElemValue>*)NewElementAlloc;
+        Elements.Capacity = NewSize;
+    }
+
+    int CalculateNewArraySize() => (Elements.Allocation != null) ? Elements.Capacity * 2 : DEFAULT_ARRAY_SIZE;
+
+    public void Leak() => OwnsInstance = false;
+
+    #region DICTIONARY INTERFACE
+
+    public ICollection<TElemKey> Keys
+    {
+        get
+        {
+            ICollection<TElemKey> Keys = new List<TElemKey>();
+            for (int i = 0; i < Elements.Size; i++)
+                Keys.Add(Elements.GetKey(i));
+            return Keys;
+        }
+    }
+
+    public ICollection<Ptr<TElemValue>> Values
+    {
+        get
+        {
+            ICollection<Ptr<TElemValue>> Values = new List<Ptr<TElemValue>>();
+            for (int i = 0; i < Elements.Size; i++)
+                Values.Add(new(Elements[i]));
+            return Values;
+        }
+    }
+
+    public int Count => Elements.Size;
+
+    public bool IsReadOnly => false;
+
+    public unsafe Ptr<TElemValue> this[TElemKey key] 
+    {
+        get => new Ptr<TElemValue>(TryGetByHash(key));
+        set => *TryGetByHash(key) = *value.Value;
+    }
+
+    public void Add(TElemKey key, Ptr<TElemValue> value)
+    {
+        if (ContainsKey(key)) return; // Don't allow duplicate keys
+        if (Hashes == null && Elements.Size + 1 >= MIN_SIZE_FOR_HASH_LIST) Rehash(HASH_INITIAL_SIZE);
+        else if (Hashes != null && Elements.Size == HashSize) Rehash(HashSize * 2);
+        if (Elements.Size == Elements.Capacity) ResizeTo(CalculateNewArraySize());
+        // Get hash index for new key
+        if (Hashes != null)
+        {
+            var hashIndex = (int)(key.GetTypeHash() & (HashSize - 1));
+            if (Hashes[hashIndex] == -1) Hashes[hashIndex] = Elements.Size;
+            else Elements.SetNextHashId(GetBucketListTail(hashIndex), Elements.Size);
+            Elements.SetNextHashId(Elements.Size, -1);
+            Elements.SetHashIndex(Elements.Size, hashIndex);
+        }
+        else
+        {
+            Elements.SetNextHashId(Elements.Size, Elements.Size - 1);
+            Elements.SetHashIndex(Elements.Size, 0);
+        }
+        // Add a new element to the array
+        Elements.SetKey(Elements.Size, key);
+        Elements[Elements.Size] = value.Value;
+        // Update the bit allocator
+        BitAllocator.Add(true);
+        Elements.Size++;
+    }
+
+    public bool ContainsKey(TElemKey key) => Keys.Contains(key);
+
+    public bool Remove(TElemKey key)
+    {
+        throw new NotImplementedException();
+    }
+
+    public bool TryGetValue(TElemKey key, [MaybeNullWhen(false)] out Ptr<TElemValue> value)
+    {
+        Ptr<TElemValue> GotValue = new(TryGetByHash(key));
+        value = GotValue.Value != null ? GotValue : new(null);
+        return GotValue.Value != null;
+    }
+
+    public void Add(KeyValuePair<TElemKey, Ptr<TElemValue>> item) => Add(item.Key, item.Value);
+
+    public void Clear()
+    {
+        throw new NotImplementedException();
+    }
+
+    public bool Contains(KeyValuePair<TElemKey, Ptr<TElemValue>> item) => this[item.Key] == item.Value;
+
+    public void CopyTo(KeyValuePair<TElemKey, Ptr<TElemValue>>[] array, int arrayIndex)
+    {
+        throw new NotImplementedException();
+    }
+
+    public bool Remove(KeyValuePair<TElemKey, Ptr<TElemValue>> item)
+    {
+        throw new NotImplementedException();
+    }
+
+    public unsafe IEnumerator<KeyValuePair<TElemKey, Ptr<TElemValue>>> GetEnumerator() => new TMapAccessorEnumerator<TElemKey, TElemValue>(Elements.Self);
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    #endregion
+
+    #region DISPOSE INTERFACE
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!Disposed)
+        {
+        }
+    }
+
+    ~TMapDictionary() => Dispose(false);
+
+    #endregion
+}
+
+public class TMapAccessorEnumerator<TElemKey, TElemValue> : IEnumerator<KeyValuePair<TElemKey, Ptr<TElemValue>>>
+    where TElemKey : unmanaged, IEquatable<TElemKey>, IMapHashable
+    where TElemValue : unmanaged
+{
+    protected int Position = -1;
+    protected unsafe TArray<TMapElementHashable<TElemKey, TElemValue>>* Self;
+
+    public unsafe TMapAccessorEnumerator(TArray<TMapElementHashable<TElemKey, TElemValue>>* _Self)
+    {
+        Self = _Self;
+    }
+
+    public unsafe KeyValuePair<TElemKey, Ptr<TElemValue>> Current => new(Self->AllocatorInstance[Position].Key, new(&Self->AllocatorInstance[Position].Value));
+
+    object IEnumerator.Current => Current;
+
+    public void Dispose() { }
+    public unsafe bool MoveNext() => ++Position < Self->ArrayNum;
+    public void Reset() => Position = -1;
+}

--- a/UE.Toolkit.Core/Types/Unreal/UE5_4_4/UDataTable.cs
+++ b/UE.Toolkit.Core/Types/Unreal/UE5_4_4/UDataTable.cs
@@ -1,4 +1,8 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
+using UE.Toolkit.Core.Types.Interfaces;
 
 namespace UE.Toolkit.Core.Types.Unreal.UE5_4_4;
 
@@ -9,4 +13,105 @@ public unsafe struct UDataTable<TRow>
     public UObjectBase BaseObj;
     public UScriptStruct* RowStruct;
     public TMap<FName, TRow> RowMap;
+}
+
+public class UDataTableManaged<TRow> : IDictionary<FName, Ptr<TRow>>, IDisposable
+    where TRow : unmanaged
+{
+    public unsafe UDataTable<TRow>* Self { get; private set; }
+
+    protected IUnrealMemoryInternal Allocator;
+    protected TMapDictionary<FName, TRow> RowMap;
+    protected bool OwnsInstance;
+    protected bool Disposed = false;
+
+    public unsafe UDataTableManaged(UDataTable<TRow>* _Self, IUnrealMemoryInternal _Allocator)
+    {
+        Self = _Self;
+        Allocator = _Allocator;
+        RowMap = new(&Self->RowMap, Allocator);
+        OwnsInstance = false;
+    }
+
+    public unsafe string Name
+    { 
+        get => Self->BaseObj.NamePrivate.ToString();
+    }
+
+    public unsafe string RowStructName => Self->RowStruct->Super.Super.Super.NamePrivate.ToString();
+
+    public unsafe void AddRow(FName RowName, TRow RowDataPtr) => Add(RowName, new(&RowDataPtr));
+
+    public ICollection<FName> GetRowNames() => Keys;
+
+    #region DICTIONARY INTERFACE
+    public ICollection<FName> Keys => RowMap.Keys;
+
+    public ICollection<Ptr<TRow>> Values => RowMap.Values;
+
+    public int Count => RowMap.Count;
+
+    public bool IsReadOnly => false;
+
+    public Ptr<TRow> this[FName key] 
+    {
+        get => RowMap[key];
+        set => RowMap[key] = value;
+    }
+
+    public void Add(FName key, Ptr<TRow> value) => RowMap.Add(key, value);
+
+    public bool ContainsKey(FName key) => RowMap.ContainsKey(key);
+
+    public bool Remove(FName key) => RowMap.Remove(key);
+
+    public bool TryGetValue(FName key, [MaybeNullWhen(false)] out Ptr<TRow> value) => RowMap.TryGetValue(key, out value);
+
+    public void Add(KeyValuePair<FName, Ptr<TRow>> item) => RowMap.Add(item);
+
+    public void Clear() => RowMap.Clear();
+
+    public bool Contains(KeyValuePair<FName, Ptr<TRow>> item) => RowMap.Contains(item);
+
+    public void CopyTo(KeyValuePair<FName, Ptr<TRow>>[] array, int arrayIndex) => RowMap.CopyTo(array, arrayIndex);
+
+    public bool Remove(KeyValuePair<FName, Ptr<TRow>> item) => RowMap.Remove(item);
+
+    public IEnumerator<KeyValuePair<FName, Ptr<TRow>>> GetEnumerator() => RowMap.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    #endregion
+
+    #region DISPOSE INTERFACE
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!Disposed)
+        {
+            if (disposing) // Dispose managed resources
+            {
+                RowMap.Dispose();
+            }
+            // Disposed unmanaged resources (for Unreal)
+            if (OwnsInstance)
+            {
+                unsafe
+                {
+                    Allocator.Free((nint)Self);
+                }
+            }
+            Disposed = true;
+        }
+    }
+
+    ~UDataTableManaged() => Dispose(false);
+
+    #endregion
 }

--- a/UE.Toolkit.Core/UE.Toolkit.Core.csproj
+++ b/UE.Toolkit.Core/UE.Toolkit.Core.csproj
@@ -6,7 +6,7 @@
         <Nullable>enable</Nullable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <PackageProjectUrl>https://github.com/RyoTune/UE.Toolkit</PackageProjectUrl>
-        <Version>1.3.0</Version>
+        <Version>1.4.0</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/UE.Toolkit.DumperMod/ModConfig.json
+++ b/UE.Toolkit.DumperMod/ModConfig.json
@@ -2,7 +2,7 @@
   "ModId": "UE.Toolkit.DumperMod",
   "ModName": "UE Toolkit: Dumper",
   "ModAuthor": "RyoTune",
-  "ModVersion": "1.3.1",
+  "ModVersion": "1.4.0",
   "ModDescription": "Unreal Engine object dumper to C# types.",
   "ModDll": "UE.Toolkit.DumperMod.dll",
   "ModIcon": "Preview.png",

--- a/UE.Toolkit.Interfaces/IUnrealMemory.cs
+++ b/UE.Toolkit.Interfaces/IUnrealMemory.cs
@@ -1,23 +1,8 @@
+using UE.Toolkit.Core.Types.Interfaces;
+
 namespace UE.Toolkit.Interfaces;
 
 /// <summary>
 /// Unreal memory API.
 /// </summary>
-public interface IUnrealMemory
-{
-    /// <summary>
-    /// Allocates a block of memory with the global <c>FMemory</c>.
-    /// </summary>
-    /// <param name="count">Number of bytes to allocate.</param>
-    /// <param name="alignment">Alignment of allocation.</param>
-    /// <returns>Pointer to the allocated memory.</returns>
-    /// <remarks>Should only be used after Unreal has finished loading.</remarks>
-    nint Malloc(nint count, int alignment = 0);
-    
-    /// <summary>
-    /// Deallocates a block of memory allocated with the global <c>FMemory</c>.
-    /// </summary>
-    /// <param name="original">Pointer to the memory block to free.</param>
-    /// <remarks>Should only be used after Unreal has finished loading.</remarks>
-    void Free(nint original);
-}
+public interface IUnrealMemory : IUnrealMemoryInternal { }

--- a/UE.Toolkit.Interfaces/UE.Toolkit.Interfaces.csproj
+++ b/UE.Toolkit.Interfaces/UE.Toolkit.Interfaces.csproj
@@ -6,7 +6,7 @@
         <Nullable>enable</Nullable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <PackageProjectUrl>https://github.com/RyoTune/UE.Toolkit</PackageProjectUrl>
-        <Version>1.3.0</Version>
+        <Version>1.4.0</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/UE.Toolkit.Reloaded/Common/Constants.cs
+++ b/UE.Toolkit.Reloaded/Common/Constants.cs
@@ -1,0 +1,6 @@
+namespace UE.Toolkit.Reloaded.Common;
+
+public static class Constants
+{
+    public static string UnrealIniId { get; } = "unreal";
+}

--- a/UE.Toolkit.Reloaded/Common/GameConfigs/Games/UE4_27_2_P3R.cs
+++ b/UE.Toolkit.Reloaded/Common/GameConfigs/Games/UE4_27_2_P3R.cs
@@ -1,4 +1,3 @@
-using UE.Toolkit.Core.Common;
 using UE.Toolkit.Core.Types.Unreal.Factories;
 using UE.Toolkit.Core.Types.Unreal.Factories.UE4_27_2;
 // ReSharper disable InconsistentNaming
@@ -8,11 +7,5 @@ namespace UE.Toolkit.Reloaded.Common.GameConfigs.Games;
 public class UE4_27_2_P3R : UE5_4_4_ClairObscur
 {
     public override string Id => "P3R";
-    public override string UObject_PostLoadSubobjects => "40 53 48 83 EC 20 48 8B 41 ?? 48 8B D9 8B 90 ?? ?? ?? ?? C1 EA 17";
-    public override string GUObjectArray => "48 8B 05 ?? ?? ?? ?? 48 8B 0C ?? 48 8D 04 ?? 48 85 C0 74 ?? 44 39 40 ?? 75 ?? F7 40 ?? 00 00 00 30 75 ?? 48 8B 00";
-    public override Func<nint, nint> GUObjectArray_Result => result => ToolkitUtils.GetGlobalAddress(result + 3) - 0x10;
-    public override string UStruct_IsChildOf => "48 85 D2 74 ?? 48 63 42 ?? 4C 8D 42 ??";
-    public override string GFNamePool => "4C 8D 05 ?? ?? ?? ?? EB ?? 48 8D 0D ?? ?? ?? ?? E8 ?? ?? ?? ?? 4C 8B C0 C6 05 ?? ?? ?? ?? 01 48 8B 44 24 ?? 48 8B D3 48 C1 E8 20 8D 0C ?? 49 03 4C ?? ?? E8 ?? ?? ?? ?? 48 8B C3";
-    public override string UEnum_GetDisplayNameTextByIndex => "48 89 5C 24 ?? 55 56 57 48 83 EC 30 48 8B FA 41 8B E8";
     public override IUnrealFactory Factory { get; } = new UnrealFactory();
 }

--- a/UE.Toolkit.Reloaded/Common/GameConfigs/Games/UE4_27_2_P3R.cs
+++ b/UE.Toolkit.Reloaded/Common/GameConfigs/Games/UE4_27_2_P3R.cs
@@ -11,6 +11,7 @@ public class UE4_27_2_P3R : UE5_4_4_ClairObscur
     public override string UObject_PostLoadSubobjects => "40 53 48 83 EC 20 48 8B 41 ?? 48 8B D9 8B 90 ?? ?? ?? ?? C1 EA 17";
     public override string GUObjectArray => "48 8B 05 ?? ?? ?? ?? 48 8B 0C ?? 48 8D 04 ?? 48 85 C0 74 ?? 44 39 40 ?? 75 ?? F7 40 ?? 00 00 00 30 75 ?? 48 8B 00";
     public override Func<nint, nint> GUObjectArray_Result => result => ToolkitUtils.GetGlobalAddress(result + 3) - 0x10;
+    public override string UStruct_IsChildOf => "48 85 D2 74 ?? 48 63 42 ?? 4C 8D 42 ??";
     public override string GFNamePool => "4C 8D 05 ?? ?? ?? ?? EB ?? 48 8D 0D ?? ?? ?? ?? E8 ?? ?? ?? ?? 4C 8B C0 C6 05 ?? ?? ?? ?? 01 48 8B 44 24 ?? 48 8B D3 48 C1 E8 20 8D 0C ?? 49 03 4C ?? ?? E8 ?? ?? ?? ?? 48 8B C3";
     public override string UEnum_GetDisplayNameTextByIndex => "48 89 5C 24 ?? 55 56 57 48 83 EC 30 48 8B FA 41 8B E8";
     public override IUnrealFactory Factory { get; } = new UnrealFactory();

--- a/UE.Toolkit.Reloaded/Common/GameConfigs/Games/UE5_4_4_ClairObscur.cs
+++ b/UE.Toolkit.Reloaded/Common/GameConfigs/Games/UE5_4_4_ClairObscur.cs
@@ -21,5 +21,6 @@ public class UE5_4_4_ClairObscur : IGameConfig
     public virtual string GMalloc => "48 8B 0D ?? ?? ?? ?? 48 85 C9 75 ?? E8 ?? ?? ?? ?? 48 8B 0D ?? ?? ?? ?? 48 8B 01 48 8B D3 FF 50 ?? 48 83 C4 20";
     public virtual string UDataTable_HandleDataTableChanged => "40 55 53 57 48 8D 6C 24 ?? 48 81 EC C0 00 00 00 8B 41";
     public virtual string UEnum_GetDisplayNameTextByIndex => "48 89 5C 24 ?? 55 56 57 48 83 EC 30 48 8B FA";
+    public virtual string FName_Ctor_Wide => "48 89 5C 24 ?? 57 48 83 EC 30 48 8B D9 48 89 54 24 ?? 33 C9 41 8B F8 4C 8B DA";
     public virtual IUnrealFactory Factory { get; } = new UnrealFactory();
 }

--- a/UE.Toolkit.Reloaded/Common/GameConfigs/Games/UE5_4_4_ClairObscur.cs
+++ b/UE.Toolkit.Reloaded/Common/GameConfigs/Games/UE5_4_4_ClairObscur.cs
@@ -16,8 +16,9 @@ public class UE5_4_4_ClairObscur : IGameConfig
     public virtual string GFNamePool => "48 8D 0D ?? ?? ?? ?? E8 ?? ?? ?? ?? 4C 8B C0 C6 05 ?? ?? ?? ?? 01 8B D3 0F B7 C3 89 44 24";
     public virtual string FNameHelper_FindOrStoreString => "48 89 74 24 ?? 57 48 83 EC 60 81 79 ?? 00 04 00 00";
 
-    public virtual string FMemory_Malloc => "48 89 5C 24 ?? 57 48 83 EC 20 48 8B F9 8B DA 48 8B 0D ?? ?? ?? ?? 48 85 C9 75 ?? E8";
-    public virtual string FMemory_Free => "48 85 C9 74 ?? 53 48 83 EC 20 48 8B D9 48 8B 0D";
+    //public virtual string FMemory_Malloc => "48 89 5C 24 ?? 57 48 83 EC 20 48 8B F9 8B DA 48 8B 0D ?? ?? ?? ?? 48 85 C9 75 ?? E8";
+    //public virtual string FMemory_Free => "48 85 C9 74 ?? 53 48 83 EC 20 48 8B D9 48 8B 0D";
+    public virtual string GMalloc => "48 8B 0D ?? ?? ?? ?? 48 85 C9 75 ?? E8 ?? ?? ?? ?? 48 8B 0D ?? ?? ?? ?? 48 8B 01 48 8B D3 FF 50 ?? 48 83 C4 20";
     public virtual string UDataTable_HandleDataTableChanged => "40 55 53 57 48 8D 6C 24 ?? 48 81 EC C0 00 00 00 8B 41";
     public virtual string UEnum_GetDisplayNameTextByIndex => "48 89 5C 24 ?? 55 56 57 48 83 EC 30 48 8B FA";
     public virtual IUnrealFactory Factory { get; } = new UnrealFactory();

--- a/UE.Toolkit.Reloaded/Common/GameConfigs/Games/UE5_4_4_ClairObscur.cs
+++ b/UE.Toolkit.Reloaded/Common/GameConfigs/Games/UE5_4_4_ClairObscur.cs
@@ -1,4 +1,3 @@
-using UE.Toolkit.Core.Common;
 using UE.Toolkit.Core.Types.Unreal.Factories;
 using UE.Toolkit.Core.Types.Unreal.Factories.UE5_4_4;
 
@@ -8,19 +7,5 @@ namespace UE.Toolkit.Reloaded.Common.GameConfigs.Games;
 public class UE5_4_4_ClairObscur : IGameConfig
 {
     public virtual string Id => "Clair Obscur";
-    public virtual string UObject_PostLoadSubobjects => "40 55 53 41 56 48 8D AC 24 ?? ?? ?? ?? 48 81 EC 10 02 00 00 48 8B 05 ?? ?? ?? ?? 48 33 C4 48 89 85 ?? ?? ?? ?? 48 8B 41";
-    public virtual string GUObjectArray => "2B 05 ?? ?? ?? ?? 44 89 05";
-    public virtual Func<nint, nint> GUObjectArray_Result { get; } = result => ToolkitUtils.GetGlobalAddress(result + 2);
-    public virtual string UStruct_IsChildOf => "48 85 D2 74 ?? 48 63 42 ?? 4C 8D 42";
-
-    public virtual string GFNamePool => "48 8D 0D ?? ?? ?? ?? E8 ?? ?? ?? ?? 4C 8B C0 C6 05 ?? ?? ?? ?? 01 8B D3 0F B7 C3 89 44 24";
-    public virtual string FNameHelper_FindOrStoreString => "48 89 74 24 ?? 57 48 83 EC 60 81 79 ?? 00 04 00 00";
-
-    //public virtual string FMemory_Malloc => "48 89 5C 24 ?? 57 48 83 EC 20 48 8B F9 8B DA 48 8B 0D ?? ?? ?? ?? 48 85 C9 75 ?? E8";
-    //public virtual string FMemory_Free => "48 85 C9 74 ?? 53 48 83 EC 20 48 8B D9 48 8B 0D";
-    public virtual string GMalloc => "48 8B 0D ?? ?? ?? ?? 48 85 C9 75 ?? E8 ?? ?? ?? ?? 48 8B 0D ?? ?? ?? ?? 48 8B 01 48 8B D3 FF 50 ?? 48 83 C4 20";
-    public virtual string UDataTable_HandleDataTableChanged => "40 55 53 57 48 8D 6C 24 ?? 48 81 EC C0 00 00 00 8B 41";
-    public virtual string UEnum_GetDisplayNameTextByIndex => "48 89 5C 24 ?? 55 56 57 48 83 EC 30 48 8B FA";
-    public virtual string FName_Ctor_Wide => "48 89 5C 24 ?? 57 48 83 EC 30 48 8B D9 48 89 54 24 ?? 33 C9 41 8B F8 4C 8B DA";
     public virtual IUnrealFactory Factory { get; } = new UnrealFactory();
 }

--- a/UE.Toolkit.Reloaded/Common/GameConfigs/IGlobalConfig.cs
+++ b/UE.Toolkit.Reloaded/Common/GameConfigs/IGlobalConfig.cs
@@ -13,8 +13,9 @@ public interface IGameConfig
     string UStruct_IsChildOf { get; }
     string GFNamePool { get; }
     string FNameHelper_FindOrStoreString { get; }
-    string FMemory_Malloc { get; }
-    string FMemory_Free { get; }
+    //string FMemory_Malloc { get; }
+    //string FMemory_Free { get; }
+    string GMalloc { get; }
     string UDataTable_HandleDataTableChanged { get; }
     string UEnum_GetDisplayNameTextByIndex { get; }
     IUnrealFactory Factory { get; }

--- a/UE.Toolkit.Reloaded/Common/GameConfigs/IGlobalConfig.cs
+++ b/UE.Toolkit.Reloaded/Common/GameConfigs/IGlobalConfig.cs
@@ -7,17 +7,5 @@ namespace UE.Toolkit.Reloaded.Common.GameConfigs;
 public interface IGameConfig
 {
     string Id { get; }
-    string UObject_PostLoadSubobjects { get; }
-    string GUObjectArray { get; }
-    Func<nint, nint> GUObjectArray_Result { get; }
-    string UStruct_IsChildOf { get; }
-    string GFNamePool { get; }
-    string FNameHelper_FindOrStoreString { get; }
-    //string FMemory_Malloc { get; }
-    //string FMemory_Free { get; }
-    string GMalloc { get; }
-    string UDataTable_HandleDataTableChanged { get; }
-    string UEnum_GetDisplayNameTextByIndex { get; }
-    string FName_Ctor_Wide { get; }
     IUnrealFactory Factory { get; }
 }

--- a/UE.Toolkit.Reloaded/Common/GameConfigs/IGlobalConfig.cs
+++ b/UE.Toolkit.Reloaded/Common/GameConfigs/IGlobalConfig.cs
@@ -18,5 +18,6 @@ public interface IGameConfig
     string GMalloc { get; }
     string UDataTable_HandleDataTableChanged { get; }
     string UEnum_GetDisplayNameTextByIndex { get; }
+    string FName_Ctor_Wide { get; }
     IUnrealFactory Factory { get; }
 }

--- a/UE.Toolkit.Reloaded/DataTables/DataTablesService.cs
+++ b/UE.Toolkit.Reloaded/DataTables/DataTablesService.cs
@@ -1,7 +1,6 @@
 using UE.Toolkit.Core.Types.Unreal.UE5_4_4;
 using UE.Toolkit.Core.Types.Wrappers;
 using UE.Toolkit.Interfaces;
-using UE.Toolkit.Reloaded.Common.GameConfigs;
 
 // ReSharper disable InconsistentNaming
 
@@ -16,7 +15,7 @@ public unsafe class DataTablesService : IDataTables
     
     public DataTablesService()
     {
-        _HandleDataTableChanged = new(HandleDataTableChangedImpl, GameConfig.Instance.UDataTable_HandleDataTableChanged);
+        _HandleDataTableChanged = new(HandleDataTableChangedImpl);
     }
 
     public void OnDataTableChanged<TRow>(string name, Action<UDataTableWrapper<TRow>> callback)

--- a/UE.Toolkit.Reloaded/Mod.cs
+++ b/UE.Toolkit.Reloaded/Mod.cs
@@ -77,6 +77,8 @@ public class Mod : ModBase, IExports
 
     private void OnModLoaded(IModV1 mod, IModConfigV1 modConfig)
     {
+        if (!Project.IsModDependent(modConfig)) return;
+        
         var modDir = _modLoader.GetDirectoryForModId(modConfig.ModId);
         var toolkitDir = Path.Join(modDir, "ue-toolkit");
         if (Directory.Exists(toolkitDir)) _toolkit.AddToolkitFolder(toolkitDir);

--- a/UE.Toolkit.Reloaded/ModConfig.json
+++ b/UE.Toolkit.Reloaded/ModConfig.json
@@ -2,7 +2,7 @@
   "ModId": "UE.Toolkit.Reloaded",
   "ModName": "UE Toolkit",
   "ModAuthor": "RyoTune",
-  "ModVersion": "1.3.0",
+  "ModVersion": "1.4.0",
   "ModDescription": "Modding toolkit for Unreal Engine games.\r\n\r\nSupported:\r\n- UE 5.4.4 (Clair Obscur)\r\n- UE 4.27.2 (P3R)",
   "ModDll": "UE.Toolkit.Reloaded.dll",
   "ModIcon": "Preview.png",

--- a/UE.Toolkit.Reloaded/Project/UE.Toolkit.Reloaded/p3r.exe/scans.ini
+++ b/UE.Toolkit.Reloaded/Project/UE.Toolkit.Reloaded/p3r.exe/scans.ini
@@ -1,0 +1,33 @@
+[Scans]
+GFNamePool=4C 8D 05 ?? ?? ?? ?? EB ?? 48 8D 0D ?? ?? ?? ?? E8 ?? ?? ?? ?? 4C 8B C0 C6 05 ?? ?? ?? ?? 01 48 8B 44 24 ?? 48 8B D3 48 C1 E8 20 8D 0C ?? 49 03 4C ?? ?? E8 ?? ?? ?? ?? 48 8B C3
+GFNamePool_RESULT=GetGlobalAddress(result + 3)
+
+FNameHelper_FindOrStoreString=DISABLED
+;FNameHelper_FindOrStoreString_RESULT=
+
+;FName_Ctor_Wide=
+;FName_Ctor_Wide_RESULT=
+
+;FText_FromString=
+;FText_FromString_RESULT=
+
+;FText_ToString=
+;FText_ToString_RESULT=
+
+;UObject_PostLoadSubobjects=
+;UObject_PostLoadSubobjects_RESULT=
+
+GUObjectArray=48 8B 05 ?? ?? ?? ?? 48 8B 0C ?? 48 8D 04 ?? 48 85 C0 74 ?? 44 39 40 ?? 75 ?? F7 40 ?? 00 00 00 30 75 ?? 48 8B 00
+GUObjectArray_RESULT=GetGlobalAddress(result + 3) - 0x10
+
+UStruct_IsChildOf=48 85 D2 74 ?? 48 63 42 ?? 4C 8D 42 ??
+;UStruct_IsChildOf_RESULT=
+
+UEnum_GetDisplayNameTextByIndex=48 89 5C 24 ?? 55 56 57 48 83 EC 30 48 8B FA 41 8B E8
+;UEnum_GetDisplayNameTextByIndex_RESULT=
+
+;UDataTable_HandleDataTableChanged=
+;UDataTable_HandleDataTableChanged_RESULT=
+
+;GMalloc=
+;GMalloc_RESULT=

--- a/UE.Toolkit.Reloaded/Project/UE.Toolkit.Reloaded/p3r.exe/unreal.ini
+++ b/UE.Toolkit.Reloaded/Project/UE.Toolkit.Reloaded/p3r.exe/unreal.ini
@@ -1,0 +1,6 @@
+[FMallocBinned2]
+Free=0x30
+GetAllocSize=0x40
+Malloc=0x10
+Realloc=0x20
+QuantizeSize=0x38

--- a/UE.Toolkit.Reloaded/Project/UE.Toolkit.Reloaded/scans.ini
+++ b/UE.Toolkit.Reloaded/Project/UE.Toolkit.Reloaded/scans.ini
@@ -1,0 +1,35 @@
+;Based on Clair Obscur (UE 5.4.4)
+
+[Scans]
+GFNamePool=48 8D 0D ?? ?? ?? ?? E8 ?? ?? ?? ?? 4C 8B C0 C6 05 ?? ?? ?? ?? 01 8B D3 0F B7 C3 89 44 24
+GFNamePool_RESULT=GetGlobalAddress(result + 3)
+
+FNameHelper_FindOrStoreString=48 89 74 24 ?? 57 48 83 EC 60 81 79 ?? 00 04 00 00
+;FNameHelper_FindOrStoreString_RESULT=
+
+;FName_Ctor_Wide=
+;FName_Ctor_Wide_RESULT=
+
+FText_FromString=48 89 5C 24 ?? 57 48 83 EC 40 83 7A ?? 01 48 8B D9 48 89 74 24 ?? 4C 89 74 24 ?? C7 44 24 ?? 00 00 00 00 7F ?? E8 ?? ?? ?? ?? 48 8B F0 48 8B 38 48 89 7C 24 ?? 48 85 FF 74 ?? 48 8B 17 48 8B CF FF 52 ?? 8B 46 ?? 4C 8D 74 24 ?? 89 44 24 ?? BE 01 00 00 00 48 8B CF EB ?? 48 8D 4C 24 ?? E8 ?? ?? ?? ?? 48 8B 7C 24 ?? 4C 8B F0 BE 02 00 00 00 48 8B 08 48 89 0B 48 85 C9 74 ?? 48 8B 11 FF 52 ?? 41 8B 46 ?? 4C 8B 74 24 ?? 89 43 ?? 40 F6 C6 02 74 ?? 48 8B 4C 24 ?? 83 E6 FD 48 85 C9 74 ?? 48 8B 01 FF 50 ?? 40 F6 C6 01 48 8B 74 24 ?? 74 ?? 48 85 FF 74 ?? 48 8B 07 48 8B CF FF 50 ?? 83 4B ?? 12
+;FText_FromString_RESULT=
+
+FText_ToString=40 53 48 83 EC 20 48 8B D9 E8 ?? ?? ?? ?? 48 8B 0B 48 8B 01 48 83 C4 20
+;FText_ToString_RESULT=
+
+UObject_PostLoadSubobjects=40 55 53 41 56 48 8D AC 24 ?? ?? ?? ?? 48 81 EC 10 02 00 00 48 8B 05 ?? ?? ?? ?? 48 33 C4 48 89 85 ?? ?? ?? ?? 48 8B 41
+;UObject_PostLoadSubobjects_RESULT=
+
+GUObjectArray=2B 05 ?? ?? ?? ?? 44 89 05
+GUObjectArray_RESULT=GetGlobalAddress(result + 2)
+
+UStruct_IsChildOf=48 85 D2 74 ?? 48 63 42 ?? 4C 8D 42
+;UStruct_IsChildOf_RESULT=
+
+UEnum_GetDisplayNameTextByIndex=48 89 5C 24 ?? 55 56 57 48 83 EC 30 48 8B FA
+;UEnum_GetDisplayNameTextByIndex_RESULT=
+
+UDataTable_HandleDataTableChanged=40 55 53 57 48 8D 6C 24 ?? 48 81 EC C0 00 00 00 8B 41
+;UDataTable_HandleDataTableChanged_RESULT=
+
+GMalloc=48 8B 0D ?? ?? ?? ?? 48 85 C9 75 ?? E8 ?? ?? ?? ?? 48 8B 0D ?? ?? ?? ?? 48 8B 01 48 8B D3 FF 50 ?? 48 83 C4 20
+GMalloc_RESULT=GetGlobalAddress(result + 3)

--- a/UE.Toolkit.Reloaded/Project/UE.Toolkit.Reloaded/unreal.ini
+++ b/UE.Toolkit.Reloaded/Project/UE.Toolkit.Reloaded/unreal.ini
@@ -1,0 +1,8 @@
+;Based on Clair Obscur (UE 5.4.4)
+
+[FMallocBinned2]
+Free=0x48
+GetAllocSize=0x58
+Malloc=0x28
+Realloc=0x38
+QuantizeSize=0x50

--- a/UE.Toolkit.Reloaded/UE.Toolkit.Reloaded.csproj
+++ b/UE.Toolkit.Reloaded/UE.Toolkit.Reloaded.csproj
@@ -40,12 +40,15 @@
         <None Update="Preview.png">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
+        <Content Include="Project\**">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </Content>
     </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="Reloaded.Mod.Interfaces" Version="2.4.0" ExcludeAssets="runtime"/>
         <PackageReference Include="Reloaded.SharedLib.Hooks" Version="1.9.0"/>
-        <PackageReference Include="RyoTune.Reloaded" Version="3.0.1"/>
+        <PackageReference Include="RyoTune.Reloaded" Version="4.1.1" />
         <PackageReference Include="Reloaded.Memory.SigScan.ReloadedII.Interfaces" Version="1.2.0"/>
     </ItemGroup>
 

--- a/UE.Toolkit.Reloaded/Unreal/UnrealMemory.cs
+++ b/UE.Toolkit.Reloaded/Unreal/UnrealMemory.cs
@@ -1,3 +1,7 @@
+using Reloaded.Hooks.Definitions;
+using System.Runtime.InteropServices;
+using UE.Toolkit.Core.Common;
+using UE.Toolkit.Core.Types.Interfaces;
 using UE.Toolkit.Interfaces;
 using UE.Toolkit.Reloaded.Common.GameConfigs;
 
@@ -5,21 +9,162 @@ using UE.Toolkit.Reloaded.Common.GameConfigs;
 
 namespace UE.Toolkit.Reloaded.Unreal;
 
+internal interface IFMalloc
+{
+    // Memory allocation stubs
+    public nint Malloc(nint size, int alignment = MemoryConstants.DEFAULT_ALIGNMENT);
+    public nint Realloc(nint ptr, nint size, int alignment = MemoryConstants.DEFAULT_ALIGNMENT);
+    public void Free(nint original);
+    public bool GetAllocSize(nint ptr, ref nint size);
+    public nint QuantizeSize(nint count, int alignment = MemoryConstants.DEFAULT_ALIGNMENT);
+
+    internal delegate nint FMemory_Malloc(nint self, nint size, int alignment = MemoryConstants.DEFAULT_ALIGNMENT);
+    internal delegate nint FMemory_Realloc(nint self, nint ptr, nint size, int alignment = MemoryConstants.DEFAULT_ALIGNMENT);
+    internal delegate void FMemory_Free(nint self, nint ptr);
+    internal delegate char FMemory_GetAllocSize(nint self, nint ptr, ref nint size);
+    internal delegate nint FMemory_QuantizeSize(nint self, nint count, int alignment = MemoryConstants.DEFAULT_ALIGNMENT);
+}
+
+// Runtime/Core/HAL/MallocBinned
+
+internal class FMallocBinned : IFMalloc
+{
+    public void Free(nint original)
+    {
+        throw new NotImplementedException();
+    }
+
+    public bool GetAllocSize(nint ptr, ref nint size)
+    {
+        throw new NotImplementedException();
+    }
+
+    public nint Malloc(nint size, int alignment = MemoryConstants.DEFAULT_ALIGNMENT)
+    {
+        throw new NotImplementedException();
+    }
+
+    public nint QuantizeSize(nint count, int alignment = 0)
+    {
+        throw new NotImplementedException();
+    }
+
+    public nint Realloc(nint ptr, nint size, int alignment = MemoryConstants.DEFAULT_ALIGNMENT)
+    {
+        throw new NotImplementedException();
+    }
+}
+
+// Runtime/Core/HAL/MallocBinned2
+// used in Persona 3 Reload
+internal class FMallocBinned2 : IFMalloc
+{
+    protected nint Ptr;
+
+    private IFunctionPtr<IFMalloc.FMemory_Malloc>? _Malloc;
+    private IFunctionPtr<IFMalloc.FMemory_Realloc>? _Realloc;
+    private IFunctionPtr<IFMalloc.FMemory_Free>? _Free;
+    private IFunctionPtr<IFMalloc.FMemory_GetAllocSize>? _GetAllocSize;
+    private IFunctionPtr<IFMalloc.FMemory_QuantizeSize>? _QuantizeSize;
+    private IReloadedHooks Hooks;
+    public FMallocBinned2(nint _Ptr, IReloadedHooks _Hooks)
+    {
+        Ptr = _Ptr;
+        Hooks = _Hooks;
+    }
+
+    public unsafe void Free(nint original)
+    {
+        if (_Free == null)
+            _Free = Hooks.CreateFunctionPtr<IFMalloc.FMemory_Free>(**(nuint**)Ptr + 0x30);
+        _Free.GetDelegate()(*(nint*)Ptr, original);
+    }
+
+    public unsafe bool GetAllocSize(nint ptr, ref nint size)
+    {
+        if (_GetAllocSize == null)
+            _GetAllocSize = Hooks.CreateFunctionPtr<IFMalloc.FMemory_GetAllocSize>(**(nuint**)Ptr + 0x40);
+        return _GetAllocSize.GetDelegate()(*(nint*)Ptr, ptr, ref size) != 0 ? true : false;
+    }
+
+    public unsafe nint Malloc(nint size, int alignment = MemoryConstants.DEFAULT_ALIGNMENT)
+    {
+        if (_Malloc == null)
+            _Malloc = Hooks.CreateFunctionPtr<IFMalloc.FMemory_Malloc>(**(nuint**)Ptr + 0x10);
+        var value = _Malloc.GetDelegate()(*(nint*)Ptr, size, alignment);
+        return value;
+    }
+
+    public unsafe nint Realloc(nint ptr, nint size, int alignment = MemoryConstants.DEFAULT_ALIGNMENT)
+    {
+        if (_Realloc == null)
+            _Realloc = Hooks.CreateFunctionPtr<IFMalloc.FMemory_Realloc>(**(nuint**)Ptr + 0x20);
+        return _Realloc.GetDelegate()(*(nint*)Ptr, ptr, size, alignment);
+    }
+
+    public unsafe nint QuantizeSize(nint count, int alignment = MemoryConstants.DEFAULT_ALIGNMENT)
+    {
+        if (_QuantizeSize == null)
+            _QuantizeSize = Hooks.CreateFunctionPtr<IFMalloc.FMemory_QuantizeSize>(**(nuint**)Ptr + 0x38);
+        return _QuantizeSize.GetDelegate()(*(nint*)Ptr, count, alignment);
+    }
+}
+
+// Runtime/Core/HAL/MallocBinned3
+
+internal class FMallocBinned3 : IFMalloc
+{
+    public void Free(nint original)
+    {
+        throw new NotImplementedException();
+    }
+
+    public bool GetAllocSize(nint ptr, ref nint size)
+    {
+        throw new NotImplementedException();
+    }
+
+    public nint Malloc(nint size, int alignment = MemoryConstants.DEFAULT_ALIGNMENT)
+    {
+        throw new NotImplementedException();
+    }
+
+    public nint QuantizeSize(nint count, int alignment = 0)
+    {
+        throw new NotImplementedException();
+    }
+
+    public nint Realloc(nint ptr, nint size, int alignment = MemoryConstants.DEFAULT_ALIGNMENT)
+    {
+        throw new NotImplementedException();
+    }
+}
+
 public class UnrealMemory : IUnrealMemory
 {
-    internal delegate nint FMemory_Malloc(nint count, int alignment = 0);
-    internal static SHFunction<FMemory_Malloc>? _FMemory_Malloc;
-    
-    internal delegate void FMemory_Free(nint original);
-    internal static SHFunction<FMemory_Free>? _FMemory_Free;
+    internal static IFMalloc? _FMemory;
 
     public UnrealMemory()
-    {       
-        _FMemory_Malloc = new(GameConfig.Instance.FMemory_Malloc);
-        _FMemory_Free = new(GameConfig.Instance.FMemory_Free);
+    {
+        ScanHooks.Add("GMalloc", GameConfig.Instance.GMalloc, (hooks, result) =>
+        {
+            _FMemory = new FMallocBinned2(ToolkitUtils.GetGlobalAddress(result + 3), hooks);
+        });
     }
     
-    public nint Malloc(nint count, int alignment = 0) => _FMemory_Malloc!.Wrapper(count, alignment);
-    
-    public void Free(nint original) => _FMemory_Free!.Wrapper(original);
+    public nint Malloc(nint count, int alignment = MemoryConstants.DEFAULT_ALIGNMENT) => _FMemory!.Malloc(count, alignment);
+
+    public void Free(nint original) => _FMemory!.Free(original);
+
+    public nint Realloc(nint ptr, nint size, int alignment = MemoryConstants.DEFAULT_ALIGNMENT) => _FMemory!.Realloc(ptr, size, alignment);
+
+    public bool GetAllocSize(nint ptr, ref nint size) => _FMemory!.GetAllocSize(ptr, ref size);
+    public nint QuantizeSize(nint count, int alignment = MemoryConstants.DEFAULT_ALIGNMENT) => _FMemory!.QuantizeSize(count, alignment);
+
+    public nint MallocZeroed(nint count, int alignment = MemoryConstants.DEFAULT_ALIGNMENT)
+    {
+        var alloc = Malloc(count, alignment);
+        unsafe { NativeMemory.Clear((void*)alloc, (nuint)count); }
+        return alloc;
+    }
 }

--- a/UE.Toolkit.Reloaded/Unreal/UnrealNames.cs
+++ b/UE.Toolkit.Reloaded/Unreal/UnrealNames.cs
@@ -1,6 +1,4 @@
-using UE.Toolkit.Core.Common;
 using UE.Toolkit.Core.Types.Unreal.UE5_4_4;
-using UE.Toolkit.Reloaded.Common.GameConfigs;
 
 // ReSharper disable InconsistentNaming
 
@@ -8,22 +6,19 @@ namespace UE.Toolkit.Reloaded.Unreal;
 
 public unsafe class UnrealNames
 {
-    //private readonly SHFunction<FNameHelper_FindOrStoreString> _FNameHelper_FindOrStoreString;
-    
     public UnrealNames()
     {
-        ScanHooks.Add(nameof(FName.GFNamePool),
-            GameConfig.Instance.GFNamePool,
-            (_, result) => FName.GFNamePool = (FNamePool*)ToolkitUtils.GetGlobalAddress(result + 3));
+        Project.Scans.AddScan(nameof(FName.GFNamePool), result => FName.GFNamePool = (FNamePool*)result);
         
-        ScanHooks.Add(nameof(FNameHelper_FindOrStoreString), GameConfig.Instance.FNameHelper_FindOrStoreString,
-            (hooks, result) =>
+        Project.Scans.AddScanHook(nameof(FNameHelper_FindOrStoreString),
+            (result, hooks) =>
             {
                 FName.FNameHelper_FindOrStoreString =
                     hooks.CreateWrapper<FNameHelper_FindOrStoreString>(result, out _);
             });
-        ScanHooks.Add(nameof(FName_Ctor_Wide), GameConfig.Instance.FName_Ctor_Wide,
-            (hooks, result) =>
+        
+        Project.Scans.AddScanHook(nameof(FName_Ctor_Wide),
+            (result, hooks) =>
             {
                 FName.FName_Constructor = hooks.CreateWrapper<FName_Ctor_Wide>(result, out _);
             });

--- a/UE.Toolkit.Reloaded/Unreal/UnrealNames.cs
+++ b/UE.Toolkit.Reloaded/Unreal/UnrealNames.cs
@@ -22,5 +22,10 @@ public unsafe class UnrealNames
                 FName.FNameHelper_FindOrStoreString =
                     hooks.CreateWrapper<FNameHelper_FindOrStoreString>(result, out _);
             });
+        ScanHooks.Add(nameof(FName_Ctor_Wide), GameConfig.Instance.FName_Ctor_Wide,
+            (hooks, result) =>
+            {
+                FName.FName_Constructor = hooks.CreateWrapper<FName_Ctor_Wide>(result, out _);
+            });
     }
 }

--- a/UE.Toolkit.Reloaded/Unreal/UnrealObjects.cs
+++ b/UE.Toolkit.Reloaded/Unreal/UnrealObjects.cs
@@ -89,9 +89,9 @@ public unsafe class UnrealObjects : IUnrealObjects
     public FText* CreateFText(string content)
     {
         var fstring = CreateFString(content);
-        var ftext = (FText*)UnrealMemory._FMemory_Malloc!.Wrapper(sizeof(FText));
+        var ftext = (FText*)UnrealMemory._FMemory!.Malloc(sizeof(FText));
         _FText_FromString!.Wrapper(ftext, fstring);
-        UnrealMemory._FMemory_Free!.Wrapper((nint)fstring);
+        UnrealMemory._FMemory!.Free((nint)fstring);
         
         return ftext;
     }
@@ -102,12 +102,12 @@ public unsafe class UnrealObjects : IUnrealObjects
     {
         content += '\0';
         
-        var fstring = (FString*)UnrealMemory._FMemory_Malloc!.Wrapper(sizeof(FString));
+        var fstring = (FString*)UnrealMemory._FMemory!.Malloc(sizeof(FString));
         fstring->Data.ArrayNum = content.Length;
         fstring->Data.ArrayMax = content.Length;
         
         var strBytes = Encoding.Unicode.GetBytes(content);
-        fstring->Data.AllocatorInstance = (char*)UnrealMemory._FMemory_Malloc.Wrapper(strBytes.Length);
+        fstring->Data.AllocatorInstance = (char*)UnrealMemory._FMemory.Malloc(strBytes.Length);
         Marshal.Copy(strBytes, 0, (nint)fstring->Data.AllocatorInstance, strBytes.Length);
         
         return fstring;


### PR DESCRIPTION
Adds wrapper structures for some of UE's data structures (`TArray`, `TMap` etc.) that implement their respective C# interface (`IList`, `IDictionary` etc.) to allow for reading and editing, including addition and removal of elements.
Some things to note:
- Added the `IUnrealMemoryInternal` interface to allow for invoking `FMemory` methods within `UE.Toolkit.Core`
- Switched to searching for `GMalloc` so only one signature is required to get access to all the `FMemory` methods (I've also added Realloc, GetAllocSize and QuantizeSize to the IUnrealMemory interface)
- Implemented `IList` for `TArray` and `TBitArray`
- WIP implementation of `IDictionary` for `TMap`: Added O(1) element searching by reading hash table and element addition

All work has been tested with Persona 3 Reload.